### PR TITLE
rootdir: Set ioprio for SurfaceFlinger

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -563,6 +563,7 @@ service surfaceflinger /system/bin/surfaceflinger
     class core
     user system
     group graphics drmrpc
+    ioprio rt 6
     onrestart restart zygote
 
 service drm /system/bin/drmserver


### PR DESCRIPTION
 * Run SurfaceFlinger with realtime priority 7.
 * Improves responsiveness of the entire UI.

Change-Id: Ib4f44910e50f12980f070c23a30e0495e5f7495b