### PR TITLE
cutils: Add support for BFQIO cgroups

### DIFF
--- a/include/cutils/iosched_policy.h
+++ b/include/cutils/iosched_policy.h
@@ -31,6 +31,8 @@ typedef enum {
 extern int android_set_ioprio(int pid, IoSchedClass clazz, int ioprio);
 extern int android_get_ioprio(int pid, IoSchedClass *clazz, int *ioprio);
 
+extern int android_set_bfqio_prio(int pid, int prio);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libcutils/iosched_policy.c
+++ b/libcutils/iosched_policy.c
@@ -22,10 +22,13 @@
 #include <unistd.h>
 
 #include <cutils/iosched_policy.h>
+#define LOG_TAG "iosched_policy"
+#include <cutils/log.h>
 
 #ifdef HAVE_ANDROID_OS
 #include <linux/ioprio.h>
 #include <sys/syscall.h>
+#include <sys/stat.h>
 #define __android_unused
 #else
 #define __android_unused __attribute__((__unused__))
@@ -56,3 +59,114 @@ int android_get_ioprio(int pid __android_unused, IoSchedClass *clazz, int *iopri
 #endif
     return 0;
 }
+
+#ifdef HAVE_ANDROID_OS
+static int __bfqio_cgroup_supported = -1;
+static int rt_cgroup_fd = -1;
+static int ui_cgroup_fd = -1;
+static int hipri_cgroup_fd = -1;
+static int fg_cgroup_fd = -1;
+static int bg_cgroup_fd = -1;
+static int idle_cgroup_fd = -1;
+static pthread_once_t the_once = PTHREAD_ONCE_INIT;
+
+static void __initialize_bfqio(void) {
+    if (!access("/sys/fs/cgroup/bfqio/tasks", F_OK)) {
+        __bfqio_cgroup_supported = 1;
+    } else {
+        __bfqio_cgroup_supported = 0;
+    }
+}
+
+static int __get_bfqio_fd(int prio) {
+
+    if (__bfqio_cgroup_supported != 1) {
+        return -1;
+    }
+
+    if (prio <= -18) {
+        if (rt_cgroup_fd < 0) {
+            rt_cgroup_fd = open("/sys/fs/cgroup/bfqio/rt/tasks", O_WRONLY | O_CLOEXEC);
+        }
+        return rt_cgroup_fd;
+    } else if (prio <= -8) {
+        if (ui_cgroup_fd < 0) {
+            ui_cgroup_fd = open("/sys/fs/cgroup/bfqio/ui/tasks", O_WRONLY | O_CLOEXEC);
+        }
+        return ui_cgroup_fd;
+    } else if (prio >= 18) {
+        if (idle_cgroup_fd < 0) {
+            idle_cgroup_fd = open("/sys/fs/cgroup/bfqio/idle/tasks", O_WRONLY | O_CLOEXEC);
+        }
+        return idle_cgroup_fd;
+    } else if (prio >= 10) {
+        if (bg_cgroup_fd < 0) {
+            bg_cgroup_fd = open("/sys/fs/cgroup/bfqio/bg/tasks", O_WRONLY | O_CLOEXEC);
+        }
+        return bg_cgroup_fd;
+    }
+
+    if (fg_cgroup_fd < 0) {
+        fg_cgroup_fd = open("/sys/fs/cgroup/bfqio/tasks", O_WRONLY | O_CLOEXEC);
+    }
+    return fg_cgroup_fd;
+}
+
+int android_set_bfqio_prio(int tid __android_unused, int prio __android_unused)
+{
+    struct stat st;
+    int fd;
+
+    pthread_once(&the_once, __initialize_bfqio);
+
+    if (__bfqio_cgroup_supported == 0)
+        return -1;
+
+    if (prio < -19 || prio > 20) {
+        return -1;
+    }
+
+    fd = __get_bfqio_fd(prio);
+    if (fd < 0)
+        return -1;
+
+#ifdef HAVE_GETTID
+    if (tid == 0) {
+        tid = gettid();
+    }
+#endif
+
+    if (tid < 200)
+        return -1;
+
+    // specialized itoa -- works for tid > 0
+    char text[22];
+    char *end = text + sizeof(text) - 1;
+    char *ptr = end;
+    *ptr = '\0';
+    while (tid > 0) {
+        *--ptr = '0' + (tid % 10);
+        tid = tid / 10;
+    }
+
+    if (write(fd, ptr, end - ptr) < 0) {
+        /*
+         * If the thread is in the process of exiting,
+         * don't flag an error
+         */
+        if (errno == ESRCH)
+            return 0;
+        SLOGV("android_set_bfqio_prio failed to write '%s' (%s); fd=%d\n",
+              ptr, strerror(errno), fd);
+        return -1;
+    }
+
+    return 0;
+}
+
+#else
+int android_set_bfqio_prio(int tid __android_unused, int prio __android_unused)
+{
+    return 0;
+}
+#endif

--- a/libutils/Threads.cpp
+++ b/libutils/Threads.cpp
@@ -45,6 +45,7 @@
 #include <utils/threads.h>
 #include <utils/Log.h>
 
+#include <cutils/iosched_policy.h>
 #include <cutils/sched_policy.h>
 
 #ifdef HAVE_ANDROID_OS
@@ -98,6 +99,7 @@ struct thread_data_t {
             androidSetThreadName(name);
             free(name);
         }
+
         return f(u);
     }
 };
@@ -338,8 +340,10 @@ int androidSetThreadPriority(pid_t tid, int pri)
     } else {
         errno = lasterr;
     }
+
+    android_set_bfqio_prio(tid, pri);
 #endif
-    
+
     return rc;
 }
 
@@ -728,6 +732,12 @@ status_t Thread::run(const char* name, int32_t priority, size_t stack)
         return UNKNOWN_ERROR;
     }
     
+#ifdef HAVE_ANDROID_OS
+    pid_t tid = __pthread_gettid(android_thread_id_t_to_pthread(mThread));
+    if (tid >= 200)
+        android_set_bfqio_prio(tid, priority);
+#endif
+
     // Do not refer to mStatus here: The thread is already running (may, in fact
     // already have exited with a valid mStatus result). The NO_ERROR indication
     // here merely indicates successfully starting the thread and does not


### PR DESCRIPTION
 * Add support for a custom hierarchy of cgroups on top of the BFQ
   IO scheduler. This allows us to place every thread into the
   right class (realtime/best-effort/idle) with a set up priority
   buckets depending on use case.
 * The benefit of doing this is pretty incredible from an
   interactivity standpoint. Realtime users (display/audio) benefit
   the most, resulting in glitch-free audio and jank-free video.
   Dexopting in the background no longer causes active harm to
   foreground tasks. Other tasks such as account syncing become
   invisible from the user's perspective.
 * Magic bullet? Perhaps.

Change-Id: I4eb911395364ce46d6dcbff43e94286ded03a97d