### PR TITLE
Revert "Add HTC Logging functions to support newer HTC props."

### DIFF
--- a/liblog/logd_write.c
+++ b/liblog/logd_write.c
@@ -89,23 +89,6 @@ int __android_log_dev_available(void)
     return (g_log_status == kLogAvailable);
 }
 
-#ifdef HTCLOG
-signed int __htclog_read_masks(char *buf __unused, signed int len __unused)
-{
-    return 0;
-}
-
-int __htclog_init_mask(const char *a1 __unused, unsigned int a2 __unused, int a3 __unused)
-{
-    return 0;
-}
-
-int __htclog_print_private(int a1 __unused, const char *a2 __unused, const char *fmt __unused, ...)
-{
-    return 0;
-}
-#endif
-
 #ifdef MOTOROLA_LOG
 /* Fallback when there is neither log.tag.<tag> nor log.tag.DEFAULT.
  * this is compile-time defaulted to "info". The log startup code

--- a/liblog/logd_write_kern.c
+++ b/liblog/logd_write_kern.c
@@ -93,23 +93,6 @@ int __android_log_dev_available(void)
     return (g_log_status == kLogAvailable);
 }
 
-#ifdef HTCLOG
-signed int __htclog_read_masks(char *buf __unused, signed int len __unused)
-{
-    return 0;
-}
-
-int __htclog_init_mask(const char *a1 __unused, unsigned int a2 __unused, int a3 __unused)
-{
-    return 0;
-}
-
-int __htclog_print_private(int a1 __unused, const char *a2 __unused, const char *fmt __unused, ...)
-{
-    return 0;
-}
-#endif
-
 #ifdef MOTOROLA_LOG
 /* Fallback when there is neither log.tag.<tag> nor log.tag.DEFAULT.
  * this is compile-time defaulted to "info". The log startup code


### PR DESCRIPTION
This reverts commit 17417fff22477c9b699d16b4aaa1c49f441e0e31.

Conflicts:
	liblog/logd_write.c
	liblog/logd_write_kern.c

Change-Id: Ic2604afcef8431c5516151fe6be7f6f4b33fc342