### PR TITLE
fastboot: format f2fs partition instead of just erase

### DIFF
--- a/fastboot/Android.mk
+++ b/fastboot/Android.mk
@@ -62,7 +62,7 @@ ifneq ($(HOST_OS),windows)
 LOCAL_STATIC_LIBRARIES += libselinux
 endif # HOST_OS != windows
 
-ifeq ($(HOST_OS),linux)
+ifneq (,$(filter linux darwin,$(HOST_OS)))
 # libf2fs_dlutils_host will dlopen("libf2fs_fmt_host_dyn")
 LOCAL_CFLAGS += -DUSE_F2FS
 LOCAL_LDFLAGS += -ldl -rdynamic -Wl,-rpath,.
@@ -75,7 +75,7 @@ endif
 include $(BUILD_HOST_EXECUTABLE)
 
 my_dist_files := $(LOCAL_BUILT_MODULE)
-ifeq ($(HOST_OS),linux)
+ifneq (,$(filter linux darwin,$(HOST_OS)))
 my_dist_files += $(HOST_LIBRARY_PATH)/libf2fs_fmt_host_dyn$(HOST_SHLIB_SUFFIX)
 endif
 $(call dist-for-goals,dist_files sdk,$(my_dist_files))


### PR DESCRIPTION
When doing fastboot -w on Darwin for f2fs partitions,
it only erase it without format it due to a flag not set in Android.mk

Change-Id: I642672467d68c75915900bb88c9aa86571140e03