### PR TITLE
bootchart: call 'bootchart_init' after remount_all is done

### DIFF
--- a/init/bootchart.c
+++ b/init/bootchart.c
@@ -32,6 +32,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <sys/stat.h>
+#include <selinux/android.h>
 #include "bootchart.h"
 
 #define VERSION         "0.8"
@@ -332,6 +333,7 @@ int   bootchart_init( void )
     count = (timeout*1000 + BOOTCHART_POLLING_MS-1)/BOOTCHART_POLLING_MS;
 
     do {ret=mkdir(LOG_ROOT,0755);}while (ret < 0 && errno == EINTR);
+    selinux_android_restorecon(LOG_ROOT, 0);
 
     file_buff_open(log_stat,  LOG_STAT);
     file_buff_open(log_procs, LOG_PROCS);

--- a/init/bootchart.h
+++ b/init/bootchart.h
@@ -26,6 +26,7 @@
 extern int   bootchart_init(void);
 extern int   bootchart_step(void);
 extern void  bootchart_finish(void);
+extern int   bootchart_init_action(int nargs, char **args);
 
 # define BOOTCHART_POLLING_MS   200   /* polling period in ms */
 # define BOOTCHART_DEFAULT_TIME_SEC    (2*60)  /* default polling time in seconds */

--- a/init/builtins.c
+++ b/init/builtins.c
@@ -49,6 +49,10 @@
 
 #include <private/android_filesystem_config.h>
 
+#if BOOTCHART
+#include "bootchart.h"
+#endif
+
 int add_environment(const char *name, const char *value);
 
 extern int init_module(void *, unsigned long, const char *);
@@ -622,8 +626,12 @@ int do_mount_all(int nargs, char **args)
          * not booting into ffbm then trigger that action.
          */
         property_get("ro.bootmode", boot_mode);
-        if (strncmp(boot_mode, "ffbm", 4))
+        if (strncmp(boot_mode, "ffbm", 4)) {
+#if BOOTCHART
+            queue_builtin_action(bootchart_init_action, "bootchart_init");
+#endif
             action_for_each_trigger("nonencrypted", action_add_queue_tail);
+        }
     } else if (ret == FS_MGR_MNTALL_DEV_NEEDS_RECOVERY) {
         /* Setup a wipe via recovery, and reboot into recovery */
         ERROR("fs_mgr_mount_all suggested recovery, so wiping data via recovery.\n");

--- a/init/init.c
+++ b/init/init.c
@@ -857,7 +857,7 @@ static int queue_property_triggers_action(int nargs, char **args)
 }
 
 #if BOOTCHART
-static int bootchart_init_action(int nargs, char **args)
+int bootchart_init_action(int nargs, char **args)
 {
     bootchart_count = bootchart_init();
     if (bootchart_count < 0) {
@@ -1145,11 +1145,6 @@ int main(int argc, char **argv)
     }
     /* run all property triggers based on current state of the properties */
     queue_builtin_action(queue_property_triggers_action, "queue_property_triggers");
-
-
-#if BOOTCHART
-    queue_builtin_action(bootchart_init_action, "bootchart_init");
-#endif
 
     for(;;) {
         int nr, i, timeout = -1;


### PR DESCRIPTION
In original codes, it call bootchart_init after late_init section.
but the data partition is not mounted yet at that moment. It will
in turn skip bootchart read/write, as it can't read out correct
setting from /data/bootchart-start and write log into correct location.

Fix is to call init function after data partition is ready.

Change-Id: I7c4f268ff94fdcee082399d9e3261f8833b1f8ea