### PR TITLE
Revert "healthd: Support QC2.0 type charger"

### DIFF
--- a/healthd/BatteryMonitor.cpp
+++ b/healthd/BatteryMonitor.cpp
@@ -143,7 +143,6 @@ BatteryMonitor::PowerSupplyType BatteryMonitor::readPowerSupplyType(const String
             { "Wipower", ANDROID_POWER_SUPPLY_TYPE_WIRELESS },
             { "DockBattery", ANDROID_POWER_SUPPLY_TYPE_DOCK_BATTERY },
             { "DockAC", ANDROID_POWER_SUPPLY_TYPE_DOCK_AC },
-            { "USB_HVDCP", ANDROID_POWER_SUPPLY_TYPE_AC },
             { NULL, 0 },
     };
 


### PR DESCRIPTION
The change is duplicated.
This reverts commit c2333e109087e1d50dcf6937bd67663cb195e020.

Change-Id: I9cf3ca50a48ca22eafe3e12c0c00562ba2cb8645